### PR TITLE
feat: add export scry path to json + to filesystem via clay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# %blog
+
+%blog lets you create and serve a simple html website from your ship.
+
+## Features
+
+- Markdown support
+- Custom CSS themes
+- Drafts
+- Serve your %blog from the same domain as your ship with zero config
+
+## Installation
+
+Install %blog with
+
+```
+|install ~hanrut-sillet-dachus-tiprel blog
+```
+
+## Export
+
+You can export your %blog with `:blog|export` in the dojo. This will create a folder inside your blog desk called `/export`.
+
+To see it, ensure you have mounted the blog desk with `|mount %blog`.

--- a/app/blog.hoon
+++ b/app/blog.hoon
@@ -31,7 +31,7 @@
   `this(themes (~(gas by themes) [%default default-theme:blog-lib]~))
 ++  on-save  !>(state)
 ++  on-load
-  |=  =vase 
+  |=  =vase
   ^-  (quip card _this)
   =+  !<(old=versioned-state vase)
   ?-    -.old
@@ -140,6 +140,38 @@
     =;  theme  ``json+!>(s+theme)
     theme:(~(got by files) t.t.path)
   ::
+        [%x %export ~]
+    =;  export  ``json+!>(export)
+    %-  pairs:enjs:format
+      :~
+        :-  'published'
+          :-  %a
+            %+  turn  ~(tap by files)
+              |=  [=^path html=@t md=@t theme=@tas]
+              :-  %a
+                :~  (path:enjs:format path)
+                    (tape:enjs:format [html ~])
+                    (tape:enjs:format [md ~])
+                    s+theme
+                ==
+        :-  'drafts'
+          :-  %a
+            %+  turn  ~(tap by drafts)
+              |=  [=^path md=@t]
+              :-  %a
+                :~  (path:enjs:format path)
+                    (tape:enjs:format [md ~])
+                ==
+        :-  'themes'
+          :-  %a
+            %+  turn  ~(tap by themes)
+              |=  [theme=@tas css=@t]
+              :-  %a
+                :~  (path:enjs:format [theme ~])
+                    (tape:enjs:format [css ~])
+                ==
+      ==
+    ::
       [%x %all-bindings ~]
     =;  the-thing  ``json+!>(the-thing)
     %-  pairs:enjs:format

--- a/app/blog.hoon
+++ b/app/blog.hoon
@@ -101,19 +101,29 @@
       [%pass /bind %arvo %e %disconnect `path.act]~
     ::
         %export
-      =/  soba-html
+      =/  soba-html=soba:clay
+        %-  zing
         %+  turn  ~(tap by files)
-          |=  [=path html=@t md=@t theme=@tas]
-            =/  t  ?~(got=(~(get by themes) theme) '' u.got)
-            [[%export %published (snoc path %html)] %ins %html !>((cat 3 html (add-style:blog-lib t)))]
-      =/  soba-md
+        |=  [=path html=@t md=@t theme=@tas]
+        ^-  soba:clay
+        =/  t  ?~(got=(~(get by themes) theme) '' u.got)
+        :~  :^  [%export %published %html (snoc path %html)]
+              %ins  %html
+            !>((cat 3 html (add-style:blog-lib t)))
+            :^  [%export %published %md (snoc path %md)]
+              %ins  %md
+            !>([md ~])
+        ==
+      =/  soba-md=soba:clay
         %+  turn  ~(tap by drafts)
-          |=  [=path md=@t]
-            [[%export %drafts (snoc path %md)] %ins %md !>([md ~])]
-      =/  soba-css
+        |=  [=path md=@t]
+        ^-  (pair ^path miso:clay)
+        [[%export %drafts (snoc path %md)] %ins %md !>([md ~])]
+      =/  soba-css=soba:clay
         %+  turn  ~(tap by themes)
-          |=  [theme=@tas css=@t]
-            [[%export %themes (snoc [theme]~ %css)] %ins %css !>(css)]
+        |=  [theme=@tas css=@t]
+        ^-  (pair path miso:clay)
+        [[%export %themes (snoc [theme]~ %css)] %ins %css !>(css)]
       :_  this
       :~  [%pass /info %arvo %c %info %blog %& soba-html]
           [%pass /info %arvo %c %info %blog %& soba-md]
@@ -160,38 +170,6 @@
     =;  theme  ``json+!>(s+theme)
     theme:(~(got by files) t.t.path)
   ::
-        [%x %export ~]
-    =;  export  ``json+!>(export)
-    %-  pairs:enjs:format
-      :~
-        :-  'published'
-          :-  %a
-            %+  turn  ~(tap by files)
-              |=  [=^path html=@t md=@t theme=@tas]
-              :-  %a
-                :~  (path:enjs:format path)
-                    (tape:enjs:format [html ~])
-                    (tape:enjs:format [md ~])
-                    s+theme
-                ==
-        :-  'drafts'
-          :-  %a
-            %+  turn  ~(tap by drafts)
-              |=  [=^path md=@t]
-              :-  %a
-                :~  (path:enjs:format path)
-                    (tape:enjs:format [md ~])
-                ==
-        :-  'themes'
-          :-  %a
-            %+  turn  ~(tap by themes)
-              |=  [theme=@tas css=@t]
-              :-  %a
-                :~  (path:enjs:format [theme ~])
-                    (tape:enjs:format [css ~])
-                ==
-      ==
-    ::
       [%x %all-bindings ~]
     =;  the-thing  ``json+!>(the-thing)
     %-  pairs:enjs:format

--- a/app/blog.hoon
+++ b/app/blog.hoon
@@ -100,6 +100,26 @@
       :_  this(files (~(del by files) path.act))
       [%pass /bind %arvo %e %disconnect `path.act]~
     ::
+        %export
+      =/  soba-html
+        %+  turn  ~(tap by files)
+          |=  [=path html=@t md=@t theme=@tas]
+            =/  t  ?~(got=(~(get by themes) theme) '' u.got)
+            [[%export %published (snoc path %html)] %ins %html !>((cat 3 html (add-style:blog-lib t)))]
+      =/  soba-md
+        %+  turn  ~(tap by drafts)
+          |=  [=path md=@t]
+            [[%export %drafts (snoc path %md)] %ins %md !>([md ~])]
+      =/  soba-css
+        %+  turn  ~(tap by themes)
+          |=  [theme=@tas css=@t]
+            [[%export %themes (snoc [theme]~ %css)] %ins %css !>(css)]
+      :_  this
+      :~  [%pass /info %arvo %c %info %blog %& soba-html]
+          [%pass /info %arvo %c %info %blog %& soba-md]
+          [%pass /info %arvo %c %info %blog %& soba-css]
+      ==
+    ::
       %save-draft    `this(drafts (~(put by drafts) [path md]:act))
       %delete-draft  `this(drafts (~(del by drafts) path.act))
       %save-theme    `this(themes (~(put by themes) [theme css]:act))

--- a/gen/blog-export.hoon
+++ b/gen/blog-export.hoon
@@ -1,0 +1,4 @@
+:-  %say
+|=  [[now=@da @ our=@p ^] *]
+:-  %json
+.^(json %gx /(scot %p our)/blog/(scot %da now)/export/json)

--- a/gen/blog-export.hoon
+++ b/gen/blog-export.hoon
@@ -1,4 +1,0 @@
-:-  %say
-|=  [[now=@da @ our=@p ^] *]
-:-  %json
-.^(json %gx /(scot %p our)/blog/(scot %da now)/export/json)

--- a/gen/blog/export.hoon
+++ b/gen/blog/export.hoon
@@ -1,0 +1,4 @@
+:-  %say
+|=  *
+:-  %blog-action
+[%export ~]

--- a/lib/docket.hoon
+++ b/lib/docket.hoon
@@ -1,1 +1,1 @@
-../../webterm/lib/docket.hoon
+../../landscape/lib/docket.hoon

--- a/mar/css.hoon
+++ b/mar/css.hoon
@@ -1,0 +1,21 @@
+::
+::::  /hoon/css/mar
+  ::
+/?    310
+=,  eyre
+=,  mimes:html
+|_  mud=@t
+++  grow                                                ::  convert to
+  |%  ++  mime  [/text/css (as-octs mud)]               ::  convert to %mime
+      ++  elem  ;style                                  ::  convert to %hymn
+                  ;-  (trip mud)
+                ==
+      ++  hymn  ;html:(head:"{elem}" body)
+  --
+++  grab
+  |%                                                    ::  convert from
+  ++  mime  |=([p=mite q=octs] (@t q.q))
+  ++  noun  @t                                         ::  clam from %noun
+  --
+++  grad  %mime
+--

--- a/mar/docket-0.hoon
+++ b/mar/docket-0.hoon
@@ -1,1 +1,1 @@
-../../webterm/mar/docket-0.hoon
+../../landscape/mar/docket-0.hoon

--- a/mar/html.hoon
+++ b/mar/html.hoon
@@ -1,0 +1,22 @@
+::
+::::  /hoon/html/mar
+  ::
+/?    310
+  ::
+::::  compute
+  ::
+=,  html
+|_  htm=@t
+++  grow                                                ::  convert to
+  ^?
+  |%                                                    ::
+  ++  mime  [/text/html (met 3 htm) htm]                ::  to %mime
+  ++  hymn  (need (de-xml htm))                         ::  to %hymn
+  --                                                    ::
+++  grab  ^?
+          |%                                            ::  convert from
+          ++  noun  @t                                  ::  clam from %noun
+          ++  mime  |=([p=mite q=octs] q.q)             ::  retrieve form %mime
+          --
+++  grad  %mime
+--

--- a/mar/md.hoon
+++ b/mar/md.hoon
@@ -1,0 +1,20 @@
+::
+::::  /hoon/md/mar
+  ::
+/?    310
+::
+=,  format
+=,  mimes:html
+|_  txt=wain
+::
+++  grab                                                ::  convert from
+  |%
+  ++  mime  |=((pair mite octs) (to-wain q.q))
+  ++  noun  wain                                        ::  clam from %noun
+  --
+++  grow
+  |%
+  ++  mime  [/text/plain (as-octs (of-wain txt))]
+  --
+++  grad  %mime
+--

--- a/sur/blog.hoon
+++ b/sur/blog.hoon
@@ -2,6 +2,7 @@
 +$  action
   $%  [%publish =path html=@t md=@t theme=@tas]
       [%unpublish =path]
+      [%export ~]
       [%save-draft =path md=@t]
       [%delete-draft =path]
       [%save-theme theme=@tas css=@t]

--- a/sur/docket.hoon
+++ b/sur/docket.hoon
@@ -1,1 +1,1 @@
-../../webterm/sur/docket.hoon
+../../landscape/sur/docket.hoon


### PR DESCRIPTION
Exporting to JSON should be something like this in the dojo but I can't quite get it to export anywhere other than `base` atm.

`*=blog=/exports/latest/json +blog!blog-export` <-- doesn't work, what am I doing wrong?